### PR TITLE
Renommage war

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ node {
     def gitURL = "https://github.com/abes-esr/licencesnationales-back.git"
     def gitCredentials = ''
     def warDir = "target/"
-    def warName = "lnevent"
+    def warName = "licencesnationales"
     def tomcatWebappsDir = "/usr/local/tomcat9-licencesNationales/webapps/"
     def tomcatServiceName = "tomcat9-licencesNationales.service"
     def slackChannel = "#notif-licencesnationales"

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
     <!-- =========================================================== -->
 
     <build>
-        <finalName>lnevent</finalName>
+        <finalName>licencesnationales</finalName>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Le war est renommé en licencesnationales.war pour permettre à l'url https://acces-dev.licencesnationales.fr/licencesnationales de fonctionner