### PR TITLE
Mise en place des locales ln-web et ln-batch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,12 @@ COPY ./docker/batch/tasks.tmpl /etc/cron.d/tasks.tmpl
 RUN dnf install -y java-11-openjdk
 COPY ./docker/batch/licencesnationales-batch1.sh /scripts/licencesnationales-batch1.sh
 COPY --from=build-image /build/batch/target/*.jar /scripts/licencesnationales-batch1.jar
-
+# Les locales fr_FR
+RUN dnf install langpacks-fr glibc-all-langpacks -y
+ENV LANG fr_FR.UTF-8
+ENV LANGUAGE fr_FR:fr
+ENV LC_ALL fr_FR.UTF-8
+# Lancement de l'entrypoint et du démon crond
 COPY ./docker/batch/docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["crond", "-n"]
@@ -51,6 +56,14 @@ CMD ["crond", "-n"]
 # Image pour le module web de licencesnationales
 FROM tomcat:9-jdk11 as web-image
 COPY --from=build-image /build/web/target/*.war /usr/local/tomcat/webapps/ROOT.war
+# Installation et configuration de la locale FR
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt -y install locales
+RUN sed -i '/fr_FR.UTF-8/s/^# //g' /etc/locale.gen && \
+    locale-gen
+ENV LANG fr_FR.UTF-8
+ENV LANGUAGE fr_FR:fr
+ENV LC_ALL fr_FR.UTF-8
+# Lancement de tomcat
 CMD [ "catalina.sh", "run" ]
 
 #FROM openjdk:11 as back-server

--- a/docker/batch/licencesnationales-batch1.sh
+++ b/docker/batch/licencesnationales-batch1.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-exec java -jar /scripts/licencesnationales-batch1.jar
+exec java -jar /scripts/licencesnationales-batch1.jar \
+          -Duser.timezone=Europe/Paris \
+          -Duser.language=fr
 


### PR DESCRIPTION
Restera à refactoriser quand on changera d'image pour passer 
- de rockylinux à alpine (pour ln-batch)
- et quand on passera de tomcat:9 à openjdk:11 (pour ln-web)

En attendant, la PR est prête à merger.